### PR TITLE
chore: remove plugin view permissions from S3 Link permission dependency

### DIFF
--- a/src/main/resources/extensions/s3os-role-template.yaml
+++ b/src/main/resources/extensions/s3os-role-template.yaml
@@ -6,7 +6,7 @@ metadata:
     halo.run/role-template: "true"
   annotations:
     rbac.authorization.halo.run/dependencies: |
-      [ "role-template-manage-attachments", "role-template-view-plugins" ]
+      [ "role-template-manage-attachments" ]
     rbac.authorization.halo.run/module: "S3 Attachments Management"
     rbac.authorization.halo.run/display-name: "S3 Link"
     rbac.authorization.halo.run/ui-permissions: |


### PR DESCRIPTION
```release-note
None
```
入口已从插件设置页移除，移除依赖插件查看权限